### PR TITLE
Imaging Spectroscopy with Regularized Photon Maps

### DIFF
--- a/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy.pro
+++ b/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy.pro
@@ -857,12 +857,15 @@ pro stx_imaging_spectroscopy, path_sci_file, path_bkg_file, aux_fits_file, time_
 
     if keyword_set(stop_here) then stop
     
-    ;correct for regularized map structures (need to have 24 visibilities saved in the map structure)
+    ;correct for regularized maps the number of visibilities saved in the map strucutre
+    ;reason: the regularized inversion does not always converge such that low-energy visibilities get rejected
     if not keyword_set(observed_vis) then begin
-      det_label = ['10a','10b','10c','9a','9b','9c','8a','8b','8c','7a','7b','7c','6a','6b','6c','5a','5b','5c','4a','4b','4c','3a','3b','3c']
-      det_num = [3,20,22,16,14,32,21,26,4,24,8,28,15,27,31,6,30,2,25,5,23,7,29,1,12,19,17,11,13,18]
+      det_num = subc_index
+      det_label = stx_ind2label(det_num)
+      det_num = det_num + 1
       
-      if n_elements(vis) NE 24 then begin
+      num_vis = n_elements(det_label)
+      if n_elements(vis) NE num_vis then begin
         ;find the missing detectors
         missing_det = []
         missing_det_num = []
@@ -870,7 +873,7 @@ pro stx_imaging_spectroscopy, path_sci_file, path_bkg_file, aux_fits_file, time_
         for pos_vis=0,n_elements(vis)-1 do begin
           vis_label = [vis_label, vis[pos_vis].label]
         endfor
-        for this_label = 0,23 do begin
+        for this_label = 0,num_vis-1 do begin
           test_label = where(vis_label EQ det_label[this_label])
           if test_label EQ (-1) then missing_det = [missing_det, det_label[this_label]]
           if test_label EQ (-1) then missing_det_num = [missing_det_num, det_num[this_label]]

--- a/imaging-spectroscopy_temporary-folder/stx_imaspec_adapt_map.pro
+++ b/imaging-spectroscopy_temporary-folder/stx_imaspec_adapt_map.pro
@@ -1,0 +1,76 @@
+;+
+;
+; NAME:
+;
+;   stx_imaspec_adapt_map
+;
+; PURPOSE:
+;
+;   Adapt a already existing stix map strucutre by changing the amount of saved visibilities
+;   Routine developed for stx_imaging_spectroscopy.pro
+;
+; CALLING SEQUENCE:
+;
+;   stx_map = stx_imaspec_adapt_map(im_map, vis, pixel)
+;
+; INPUTS:
+;
+;   im_map: existing stix map
+;
+;   vis: new visibility structure, which should be used for the map structure
+;   
+;   pixel: bi-dimensional array containing the pixel size in arcsec
+;
+; OUTPUTS:
+;
+;   Map structure, the same as when using stx_make_map.pro routine
+;
+; HISTORY: December 2023, Stiefel M.Z., created
+;
+; CONTACT:
+;   muriel.stiefel@fhnw.ch
+;-
+
+function stx_imaspec_adapt_map, im_map, vis, pixel
+
+  imsize = size(im_map.data, /dim)
+  F = vis_map2vis_matrix(vis.u, vis.v, imsize, pixel)
+  mapvis = F # im_map.data[*]
+
+  pred_vis = {mapvis: mapvis, $     ; Complex visibility values predicted from the map
+    isc:    vis.ISC, $    ; Subcollimator index
+    label:  vis.LABEL, $  ; Subcollimator label
+    u: vis.u, $           ; U coordinates of the frequencies sampled by the subcollimators
+    v: vis.v  $           ; V coordinates of the frequencies sampled by the subcollimators
+  }
+
+
+  out_map = make_map(im_map.data)
+
+  out_map.ID = im_map.id
+  out_map.dx = im_map.dx
+  out_map.dy = im_map.dy
+  out_map.time = im_map.time
+  out_map.dur  = im_map.dur
+  out_map.xc = im_map.xc
+  out_map.yc = im_map.yc
+  out_map.roll_angle = im_map.roll_angle
+
+  ;; Add properties
+  energy_range   = im_map.ENERGY_RANGE
+
+  add_prop, out_map, energy_range   = im_map.ENERGY_RANGE 
+  add_prop, out_map, obs_vis        = vis                   
+  add_prop, out_map, pred_vis       = pred_vis         
+  add_prop, out_map, aux_data       = im_map.aux_data              
+  add_prop, out_map, time_range     = im_map.time_range            
+  add_prop, out_map, rsun = im_map.RSUN
+  add_prop, out_map, b0   = im_map.B0
+  add_prop, out_map, l0   = im_map.L0
+  add_prop, out_map, coord_frame = 'SOLO HPC'
+  add_prop, out_map, units = 'counts cm^-2 asec^-2 s^-1 keV^-1'
+
+  return, out_map
+
+
+end

--- a/imaging-spectroscopy_temporary-folder/stx_ind2label.pro
+++ b/imaging-spectroscopy_temporary-folder/stx_ind2label.pro
@@ -1,0 +1,31 @@
+;+
+;
+; NAME:
+;   stx_ind2label
+;
+; PURPOSE:
+;   Return an array of detector labels from the corresponding array of indices
+;   Inverse function of stx_label2ind
+;
+; INPUTS:
+;   input_indices: array containing detector indices to be converted to corresponding labels (number 10-1 (resolution) and letter a-c (orientation)))
+;
+; HISTORY: December 2023, Stiefel M.Z., initial release
+;
+;-
+
+FUNCTION stx_ind2label, input_indices
+
+  ref_label = ['10a','10b','10c','9a','9b','9c','8a','8b','8c','7a','7b','7c','6a','6b','6c','5a','5b','5c','4a','4b','4c','3a','3b','3c','2a','2b','2c','1a','1b','1c']
+  ref_ind = stx_label2ind(ref_label)
+  
+  label = strarr(n_elements(input_indices))
+  for i=0,n_elements(input_indices)-1 do begin
+    
+    label[i] = ref_label[where(ref_ind EQ input_indices[i])]
+    
+  endfor
+
+  return, label
+
+END


### PR DESCRIPTION
These changes are done such that we can use regularized photon maps in OSPEX for imaging spectroscopy

The problem: not always all visibilities can be used for the inversion (as they not converge), this can lead to different map structures depending for different energy ranges

Code: Correction for the problem above -> the missing visibilites are added, but have value 0 in them
This includes changes in the routine stx_imaging_spectroscopy.pro and a new routine stx_imaspec_adapt_map.pro (which creates new maps with now all visibilities

Future correction: currently it will always correct to 24 visibilities for each map. 
If the finest grids will be included (30 visibilities), the code will not correct for the effect correctly anymore. 
I will implement this later!