### PR TITLE
Add Mapcenter keyword

### DIFF
--- a/imaging-spectroscopy_temporary-folder/demo_imaging_spectroscopy.pro
+++ b/imaging-spectroscopy_temporary-folder/demo_imaging_spectroscopy.pro
@@ -57,6 +57,9 @@ uncertainty = 1
 ;; undo the configuration_fwdfit keyword
 ;configuration_fwdfit = ['circle','circle']
 
+;;; If the mapcenter is known or should be defined, use the keyword mapcenter
+; mapcenter = [x-coordinate, y-coordinate]
+
 ;;;;; If you want to set the location of the boxes
 ;   box_location         : instead of selecting the boxes on the screen, one can pass it and then it will
 ;                          be used for all the energy bins. One has to give the coordinates of the bottom left
@@ -85,6 +88,7 @@ stx_imaging_spectroscopy, $
   time_range, $
   energy_max_inversion, $
   ;; --- Optional inputs and keywords
+  ; mapcenter = mapcenter
   ;/select_loc, $
   ;/observed_vis, $
   path_sav_folder = path_sav_folder, $

--- a/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy.pro
+++ b/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy.pro
@@ -42,6 +42,8 @@
 ;                          visibilities. If the keyword "/observed_vis" is set, then this is ignored.
 ;                          Default is 9 keV (we cannot go lower with the regularized visibilities).
 ;
+;   mapcenter            : array with x,y coordinates for the mapcenter (if known)
+;
 ;   configuration_fwdfit : array containing the configuration of the forward fitting algorithm
 ;
 ;   source_loc           : array containing the location of the source (if known a priori).
@@ -150,6 +152,7 @@ pro stx_imaging_spectroscopy, path_sci_file, path_bkg_file, aux_fits_file, time_
   observed_vis = observed_vis, $
   energy_min_inversion = energy_min_inversion, $
   configuration_fwdfit = configuration_fwdfit, $
+  mapcenter = mapcenter, $
   source_loc = source_loc, $
   source_fwhm = source_fwhm, $
   min_fwhm = min_fwhm, $
@@ -195,6 +198,7 @@ pro stx_imaging_spectroscopy, path_sci_file, path_bkg_file, aux_fits_file, time_
       ;; --- Optional inputs and keywords
       energy_min_inversion = energy_min_inversion, $
       configuration_fwdfit = configuration_fwdfit, $
+      mapcenter = mapcenter, $
       source_loc = source_loc, $
       source_fwhm = source_fwhm, $
       min_fwhm = min_fwhm, $
@@ -236,6 +240,7 @@ pro stx_imaging_spectroscopy, path_sci_file, path_bkg_file, aux_fits_file, time_
       observed_vis = observed_vis, $
       energy_min_inversion = energy_min_inversion, $
       configuration_fwdfit = configuration_fwdfit, $
+      mapcenter = mapcenter, $
       source_loc = source_loc, $
       source_fwhm = source_fwhm, $
       min_fwhm = min_fwhm, $

--- a/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy_electron.pro
+++ b/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy_electron.pro
@@ -56,6 +56,8 @@
 ;
 ;   configuration_fwdfit : array containing the configuration of the forward fitting algorithm
 ;
+;   mapcenter            : array with x,y coordinates for the mapcenter (if known)
+;
 ;   source_loc           : array containing the location of the source (if known a priori).
 ;                          This has to have the same number of elements as configuration_fwdfit.
 ;                          This keyword is mutually exclusive with /select_location.
@@ -162,6 +164,7 @@ pro stx_imaging_spectroscopy_electron, path_sci_file, path_bkg_file, aux_fits_fi
   ;; --- Optional inputs and keywords
   energy_min_inversion = energy_min_inversion, $
   configuration_fwdfit = configuration_fwdfit, $
+  mapcenter = mapcenter, $
   source_loc = source_loc, $
   source_fwhm = source_fwhm, $
   min_fwhm = min_fwhm, $
@@ -298,14 +301,11 @@ pro stx_imaging_spectroscopy_electron, path_sci_file, path_bkg_file, aux_fits_fi
   aux_data = stx_create_auxiliary_data(aux_fits_file, time_range_so)
 
   ;;;;; Estimate flare location, if not already specified
-  if not keyword_set(source_loc) then begin
+  if not keyword_set(mapcenter) then begin
     stx_estimate_flare_location, path_sci_file, time_range_so, aux_data, flare_loc=flare_loc, path_bkg_file=path_bkg_file
     xy_flare_stix = flare_loc
     mapcenter = flare_loc
-  endif else begin
-    xy_flare_stix = source_loc[*,0]
-    mapcenter = xy_flare_stix
-  endelse
+  endif
 
   ;;;;; Coordinate transformaion
   ; from Helioprojective Cartesian to STIX coordinate frame

--- a/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy_electron.pro
+++ b/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy_electron.pro
@@ -305,7 +305,10 @@ pro stx_imaging_spectroscopy_electron, path_sci_file, path_bkg_file, aux_fits_fi
     stx_estimate_flare_location, path_sci_file, time_range_so, aux_data, flare_loc=flare_loc, path_bkg_file=path_bkg_file
     xy_flare_stix = flare_loc
     mapcenter = flare_loc
-  endif
+  endif else begin
+    xy_flare_stix = mapcenter
+    mapcenter = mapcenter
+  endelse
 
   ;;;;; Coordinate transformaion
   ; from Helioprojective Cartesian to STIX coordinate frame

--- a/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy_electron.pro
+++ b/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy_electron.pro
@@ -301,10 +301,14 @@ pro stx_imaging_spectroscopy_electron, path_sci_file, path_bkg_file, aux_fits_fi
   aux_data = stx_create_auxiliary_data(aux_fits_file, time_range_so)
 
   ;;;;; Estimate flare location, if not already specified
-  if not keyword_set(mapcenter) then begin
-    stx_estimate_flare_location, path_sci_file, time_range_so, aux_data, flare_loc=flare_loc, path_bkg_file=path_bkg_file
+  if not keyword_set(mapcenter) and not keyword_set(source_loc) then begin
+    stx_estimate_flare_location, path_sci_file, time_range_so, aux_data, flare_loc=flare_loc, path_bkg_file=path_bkg_file, energy_range=energy_range
     xy_flare_stix = flare_loc
     mapcenter = flare_loc
+  endif else if not keyword_set(mapcenter) and keyword_set(source_loc) then begin
+    n_sources_here = n_elements(source_loc)/2
+    xy_flare_stix = total(source_loc,2)/n_sources_here
+    mapcenter = xy_flare_stix
   endif else begin
     xy_flare_stix = mapcenter
     mapcenter = mapcenter

--- a/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy_photon.pro
+++ b/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy_photon.pro
@@ -59,6 +59,8 @@
 ;
 ;   configuration_fwdfit : array containing the configuration of the forward fitting algorithm
 ;
+;   mapcenter            : array with x,y coordinates for the mapcenter (if known)
+;
 ;   source_loc           : array containing the location of the source (if known a priori).
 ;                          This has to have the same number of elements as configuration_fwdfit.
 ;                          This keyword is mutually exclusive with /select_location.
@@ -164,6 +166,7 @@ pro stx_imaging_spectroscopy_photon, path_sci_file, path_bkg_file, aux_fits_file
   observed_vis = observed_vis, $
   energy_min_inversion = energy_min_inversion, $
   configuration_fwdfit = configuration_fwdfit, $
+  mapcenter = mapcenter, $
   source_loc = source_loc, $
   source_fwhm = source_fwhm, $
   min_fwhm = min_fwhm, $
@@ -316,15 +319,11 @@ pro stx_imaging_spectroscopy_photon, path_sci_file, path_bkg_file, aux_fits_file
   
   
   ;;;;; Estimate flare location, if not already specified
-  if not keyword_set(source_loc) then begin
+  if not keyword_set(mapcenter) then begin
     stx_estimate_flare_location, path_sci_file, time_range_so, aux_data, flare_loc=flare_loc, path_bkg_file=path_bkg_file, energy_range=energy_range
     xy_flare_stix = flare_loc
     mapcenter = flare_loc
-  endif else begin
-    xy_flare_stix = source_loc[*,0]
-    mapcenter = xy_flare_stix
-  endelse
-  
+  endif 
   
   ;;;;; Coordinate transformaion
   ; from Helioprojective Cartesian to STIX coordinate frame

--- a/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy_photon.pro
+++ b/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy_photon.pro
@@ -319,10 +319,14 @@ pro stx_imaging_spectroscopy_photon, path_sci_file, path_bkg_file, aux_fits_file
   
   
   ;;;;; Estimate flare location, if not already specified
-  if not keyword_set(mapcenter) then begin
+  if not keyword_set(mapcenter) and not keyword_set(source_loc) then begin
     stx_estimate_flare_location, path_sci_file, time_range_so, aux_data, flare_loc=flare_loc, path_bkg_file=path_bkg_file, energy_range=energy_range
     xy_flare_stix = flare_loc
     mapcenter = flare_loc
+  endif else if not keyword_set(mapcenter) and keyword_set(source_loc) then begin
+    n_sources_here = n_elements(source_loc)/2
+    xy_flare_stix = total(source_loc,2)/n_sources_here
+    mapcenter = xy_flare_stix
   endif else begin
     xy_flare_stix = mapcenter
     mapcenter = mapcenter

--- a/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy_photon.pro
+++ b/imaging-spectroscopy_temporary-folder/stx_imaging_spectroscopy_photon.pro
@@ -323,7 +323,10 @@ pro stx_imaging_spectroscopy_photon, path_sci_file, path_bkg_file, aux_fits_file
     stx_estimate_flare_location, path_sci_file, time_range_so, aux_data, flare_loc=flare_loc, path_bkg_file=path_bkg_file, energy_range=energy_range
     xy_flare_stix = flare_loc
     mapcenter = flare_loc
-  endif 
+  endif else begin
+    xy_flare_stix = mapcenter
+    mapcenter = mapcenter
+  endelse
   
   ;;;;; Coordinate transformaion
   ; from Helioprojective Cartesian to STIX coordinate frame


### PR DESCRIPTION
To the routines
stx_imaging_spectroscopy.pro
stx_imaging_spectroscopy_photon.pro
stx_imaging_spectroscopy_electron.pro
the keyword mapcenter is added (if user wants to give in mapcenter rather than having stx_estimate_flare_location calculating it). 

The demo for imaging spectroscopy is updated accordingly. 